### PR TITLE
Spam protection feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ gradle-wrapper.jar
 
 # Manifest MF
 *.MF
+
+# Bin folder
+bin/

--- a/src/main/java/com/acmcsuf/crying_counter/Trigger.java
+++ b/src/main/java/com/acmcsuf/crying_counter/Trigger.java
@@ -46,6 +46,7 @@ public class Trigger extends ListenerAdapter
     int max = 5;
 
     final int MAX_TRIGGERS = 50;
+    final int MINIMUM_SECONDS_BETWEEN_MESSAGES = 30;
 
     // SLF4J Logger
     final Logger log = LoggerFactory.getLogger( Trigger.class );
@@ -399,6 +400,39 @@ public class Trigger extends ListenerAdapter
                 {
                     continue;
                 }
+
+                /*
+                 * Spam Check
+                 * 
+                 * Spam check should be done by checking the last 50 messages in the channel and comparing the
+                 * timestamps of the current triggering message and the last triggering message. If the difference
+                 * is less than MINIMUM_SECONDS_BETWEEN_MESSAGES, the message should be ignored.
+                 */
+                MessageHistory previousHistory = event.getChannel().getHistoryBefore( event.getMessageId(), 50 ).complete();
+
+                for ( Message message : previousHistory.getRetrievedHistory() )
+                {
+
+                    // Check if message contains trigger phrase
+                    if ( inSet( message.getContentRaw().toLowerCase(), triggerMap.get( id ) ) )
+                    {
+
+                        // Check if message was sent by the same user
+                        if ( !message.getAuthor().getId().equals( member.getId() ) )
+                        {
+
+                            // Check if the difference between the current message and the previous message is less than MINIMUM_SECONDS_BETWEEN_MESSAGES
+                            long difference = event.getMessage().getTimeCreated().toEpochSecond() - message.getTimeCreated()
+                                    .toEpochSecond();
+
+                            if ( difference < MINIMUM_SECONDS_BETWEEN_MESSAGES )
+                            {
+                                return;
+                            }
+                        }
+                    }
+                }
+
 
                 // Embed
                 EmbedBuilder builder = new EmbedBuilder()

--- a/src/main/java/com/acmcsuf/crying_counter/Trigger.java
+++ b/src/main/java/com/acmcsuf/crying_counter/Trigger.java
@@ -367,6 +367,7 @@ public class Trigger extends ListenerAdapter
         String messageContent = event.getMessage().getContentRaw().toLowerCase();
 
         // Loop through HashMap keySet
+        userLoop:
         for ( String id : triggerMap.keySet() )
         {
 
@@ -427,7 +428,7 @@ public class Trigger extends ListenerAdapter
 
                             if ( difference < MINIMUM_SECONDS_BETWEEN_MESSAGES )
                             {
-                                return;
+                                continue userLoop;
                             }
                         }
                     }


### PR DESCRIPTION
## Feature

Adds simple spam check while scanning for trigger messages. 

## Overview

Spam check should be done by checking the last 50 messages in the channel and comparing the timestamps of the current triggering message and the last triggering message. If the difference is less than the defined constant, the message should be ignored.

Using labeled loops, we simply continue the loop that iterates through the trigger key set when the constant exceeds the difference.